### PR TITLE
設定値の見直し

### DIFF
--- a/src/main/resources/common.properties
+++ b/src/main/resources/common.properties
@@ -6,7 +6,7 @@
 nablarch.commonProperty.basePackage=com.nablarch.example.action
 
 # APIのルート
-nablarch.webApi.applicationPath=
+nablarch.webApi.applicationPath=/
 
 # 業務日付のデフォルト区分
 nablarch.businessDateProvider.defaultSegment=01
@@ -36,6 +36,9 @@ nablarch.connectionFactory.statementReuse=true
 nablarch.languageAttribute.defaultLanguage=ja
 nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
+
+# スレッドコンテキストに格納されるデフォルトのタイムゾーン
+nablarch.timeZoneAttribute.defaultTimeZone=Asia/Tokyo
 
 # 未ログイン時、ログに出力するユーザID
 nablarch.userIdAttribute.anonymousId=guest

--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -2,9 +2,6 @@
 ## 開発環境用設定ファイル
 ##
 
-# JNDIでDataSourceを取得する際のリソース名
-nablarch.connectionFactory.jndiResourceName=
-
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
 nablarch.db.jdbcDriver=org.h2.Driver
 


### PR DESCRIPTION
nablarch.webApi.applicationPathの値が空になっていたので、明示的に"/"を設定。
不足していたデフォルトタイムゾーンの設定値を追加。
使用されないnablarch.connectionFactory.jndiResourceNameの設定値を削除。

ユニットテストとREADME記載の動作確認を実施済。