### PR TITLE
Jackson-databindのバージョンアップにあわせてjerseyもバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,19 +158,19 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.29.1</version>
+      <version>2.38</version>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.29.1</version>
+      <version>2.38</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.29.1</version>
+      <version>2.38</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
https://github.com/nablarch/nablarch-testing-rest/pull/30

バージョンがずれるとエラーになるためバージョンアップ