### PR TITLE
GSPプラグインバージョン更新(v5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
-        <version>4.7.0</version>
+        <version>4.8.0-SNAPSHOT</version>
         <configuration>
           <erdFile>src/main/resources/entity/data-model.edm</erdFile>
 


### PR DESCRIPTION
https://github.com/nablarch/nablarch-single-module-archetype/pull/200 の変更を反映するため、gsp-dba-maven-pluginのバージョンを更新しました。

プロジェクトのビルド時に表示されるgsp-dba-maven-pluginのバージョンが更新されていること、exampleの`README.md`レベルの確認まで行っています。